### PR TITLE
Created concrete class for AtomicClock #20

### DIFF
--- a/src/clockSim/AtomicClock.java
+++ b/src/clockSim/AtomicClock.java
@@ -1,0 +1,5 @@
+package clockSim;
+
+public class AtomicClock extends QuantumClock {
+
+}

--- a/src/clockSim/QuantumClock.java
+++ b/src/clockSim/QuantumClock.java
@@ -1,0 +1,5 @@
+package clockSim;
+
+public abstract class QuantumClock {
+
+}

--- a/src/clockSim/QutantumClock.java
+++ b/src/clockSim/QutantumClock.java
@@ -1,5 +1,0 @@
-package clockSim;
-
-public abstract class QutantumClock {
-
-}


### PR DESCRIPTION
Resolved #20 

There was a misspelling error for the abstract class QuantumClock, so I fixed it to be spelled correctly and then made the concrete class for the AtomicClock. 